### PR TITLE
Fix README incorrect license reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![crates.io](https://img.shields.io/crates/v/output_vt100.svg?style=flat)](https://crates.io/crates/output_vt100)
 [![Released API docs](https://docs.rs/output_vt100/badge.svg)](https://docs.rs/output_vt100)
 [![Downloads](https://img.shields.io/crates/d/output_vt100.svg?style=flat)](https://crates.io/crates/output_vt100)
-[![GPL-3.0 Licensed](https://img.shields.io/crates/l/output_vt100.svg?style=flat)](https://crates.io/crates/output_vt100)
+[![MIT Licensed](https://img.shields.io/crates/l/output_vt100.svg?style=flat)](https://crates.io/crates/output_vt100)
 [![AppVeyor CI](https://img.shields.io/appveyor/ci/Phundrak/output-vt100-rs.svg?style=flat)](https://ci.appveyor.com/project/Phundrak/output-vt100-rs)
 [![pipeline status](http://labs.phundrak.fr/phundrak/output-vt100-rs/badges/master/pipeline.svg)](http://labs.phundrak.fr/phundrak/output-vt100-rs/commits/master)
 


### PR DESCRIPTION
Was referencing that it was using GPL license, not MIT. 

Which http://fossa.io open source license scanner picked up and triggered on.